### PR TITLE
[feat] 이미지 프로필 컴포넌트 추가

### DIFF
--- a/components/Header/Header.module.scss
+++ b/components/Header/Header.module.scss
@@ -78,32 +78,6 @@
       .nickname {
         color: $blue600;
       }
-
-      .profile-image-container {
-        position: relative;
-        display: inline-block; /* 이미지 크기에 맞추어 컨테이너 크기 조정 */
-      }
-
-      .profile-image-background {
-        border-radius: 50%;
-        width: 2.75rem;
-        height: 2.75rem;
-        background-color: $gray200;
-      }
-
-      .profile-image-container::before {
-        content: "";
-        position: absolute;
-        inset: -2px;
-        border-radius: 50%;
-        background: linear-gradient(
-          90deg,
-          rgba(51, 96, 255, 1) 0%,
-          rgba(50, 236, 180, 1) 50%,
-          rgba(38, 163, 191, 1) 100%
-        );
-        z-index: -1; /* 이미지 뒤에 배치 */
-      }
     }
   }
 }

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -7,6 +7,7 @@ import classNames from "classnames/bind";
 import { PAGE_PATH } from "@/constants/pagePath";
 
 import styles from "./Header.module.scss";
+import ProfileImage from "../ProfileImage";
 
 const cn = classNames.bind(styles);
 
@@ -14,6 +15,9 @@ const isAnimation = {
   dashboard: false,
   calender: false,
 };
+
+// 임시 이미지 url 추후 삭제 예정
+const tempImageUrl = "https://i.pinimg.com/564x/c5/5c/76/c55c762ce418abefd071aa7e81c5a213.jpg";
 
 // 로그인 정보에 따라 닉네임, 프로필 이미지 변경(유저 정보 전역 상태 관리?)
 export default function Header() {
@@ -73,16 +77,7 @@ export default function Header() {
             반가워요, <span className={cn("nickname")}>달맞이 토끼</span> 님
           </div>
 
-          <figure className={cn("profile-image-container")}>
-            <figcaption className={cn("profile-image-background")}>
-              <Image
-                src="/icons/default-profile.svg"
-                width={44}
-                height={44}
-                alt="유저 프로필 이미지"
-              />
-            </figcaption>
-          </figure>
+          <ProfileImage imageUrl={tempImageUrl} />
         </div>
       </nav>
     </header>

--- a/components/ProfileImage/ProfileImage.module.scss
+++ b/components/ProfileImage/ProfileImage.module.scss
@@ -1,0 +1,28 @@
+.profile-image-container {
+  position: relative;
+}
+
+.profile-image-background {
+  border-radius: 50%;
+  width: 2.75rem;
+  height: 2.75rem;
+}
+
+.profile-image {
+  border-radius: 50%;
+}
+
+.profile-image-container::before {
+  content: "";
+  position: absolute;
+  height: 2.875rem;
+  inset: -2px;
+  border-radius: 50%;
+  background: linear-gradient(
+    90deg,
+    rgba(51, 96, 255, 1) 0%,
+    rgba(50, 236, 180, 1) 50%,
+    rgba(38, 163, 191, 1) 100%
+  );
+  z-index: -1; /* 이미지 뒤에 배치 */
+}

--- a/components/ProfileImage/index.tsx
+++ b/components/ProfileImage/index.tsx
@@ -1,0 +1,34 @@
+import Image from "next/image";
+
+import classNames from "classnames/bind";
+
+import styles from "./ProfileImage.module.scss";
+
+interface ProfileImageProps {
+  imageUrl: string;
+}
+
+const cn = classNames.bind(styles);
+
+export default function ProfileImage({ imageUrl }: ProfileImageProps) {
+  if (imageUrl) {
+    return (
+      <figure className={cn("profile-image-container")}>
+        <Image
+          className={cn("profile-image")}
+          src={imageUrl}
+          width={44}
+          height={44}
+          alt="유저 프로필 이미지"
+        />
+      </figure>
+    );
+  }
+
+  // imageUrl이 없을 경우 기본 이미지로 대체
+  return (
+    <figure className={cn("profile-image-background")}>
+      <Image src="/icons/default-profile.svg" width={44} height={44} alt="유저 프로필 이미지" />
+    </figure>
+  );
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,14 +12,14 @@ const nextConfig = {
     // 매번 가져올 파일 추가
     prependData: `@import "styles/globals.scss";`,
   },
-  // images: {
-  //   remotePatterns: [
-  //     {
-  //       protocol: "https",
-  //       hostname: "s3 도메인 추가 예정",
-  //     },
-  //   ],
-  // },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "*", //s3 도메인 추가 예정
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
# 🎯 이슈 번호

- #24 

## 🏁 작업 내용(필수)

- 헤더에 들어가는 이미지 프로필 컴포넌트 분리

## 💬 리뷰 요구 사항

- 따로 컴포넌트로 분리한 이유는 디자인 시안에 유저 프로필 이미지가 있으면 그라데이션 테두리가 추가 되는데 분리하는 것이 유지보수가 편할 것 같아서 분리하였습니다!

## 📢 참고 사항

- `next.config.js` 도메인을 일단 `*`로 설정하였습니다. 추후에 백엔드분들이 S3 도메인 주시면 그걸로 변경 할 예정입니다!
