### PR TITLE
[fix] 빌드 시간 단축

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -14,5 +14,5 @@ permissions:
 hooks:
   ApplicationStart:
     - location: deploy.sh
-      timeout: 300
+      timeout: 600 # 10분
       runas: ubuntu

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 cd /home/ubuntu/calander-front
+
+echo "최신 변경 사항 가져오기..."
 git pull origin develop
-sudo npm install
+
+echo "의존성 설치..."
+export NODE_ENV=production # 배포 환경에서만 필요한 의존성 설치
+sudo npm ci --only=production # 빌드 결과와 종속성을 캐시하여 반복 빌드 시간 단축, .next/cache에 저장 후 재사용
+
+echo "빌드 실행 중..."
 sudo npm run build
+
+echo "앱 재실행..."
 pm2 restart tickita_app
+
+echo "배포 성공!"


### PR DESCRIPTION
# 🎯 이슈 번호

- #75 

## 🏁 작업 내용(필수)

- 기존 설정은 `timeout: 300`으로 설정되어 5분 안에 `deploy.sh`의 작업이 끝나야 하는데 5분이 넘어 CodeDeploy 배포 실패하는 경우가 종종 있어 빌드 시간을 단축하였습니다.
- 배포 환경에서는 필요한 의존성만 설치(`devDependencies` 설치 X)
- 빌드 결과와 종속성을 캐시하여 반복 빌드 시간 단축
- `timeout: 600`(10분)으로 증가

## 💬 리뷰 요구 사항

- 일단 설정은 했는데 이렇게 했을 때도 CodeDeploy 배포가 실패하면 `timeout`을 더 늘려야 할 것 같습니다!
![스크린샷 2024-06-21 오후 1 12 02](https://github.com/tickita-project/tickita-front/assets/154664697/144b6265-fd7d-4d36-818b-05dedcc8be3b)
![스크린샷 2024-06-21 오후 1 12 14](https://github.com/tickita-project/tickita-front/assets/154664697/2fe84492-fd29-4044-966e-887088a99871)



