### PR TITLE
[refactor] 미들웨어 및 로그인 로직 수정

### DIFF
--- a/middleware.page.ts
+++ b/middleware.page.ts
@@ -6,16 +6,20 @@ export const middleware = (request: NextRequest) => {
   const REFRESH_TOKEN = request.cookies.get("REFRESH_TOKEN");
 
   if (!REFRESH_TOKEN) {
-    return NextResponse.redirect(new URL(PAGE_PATH.SIGN_IN, request.url));
+    if (!request.nextUrl.pathname.startsWith(PAGE_PATH.SIGN_IN) && !request.nextUrl.pathname) {
+      return NextResponse.redirect(new URL(PAGE_PATH.SIGN_IN, request.url));
+    }
   }
 
-  if (REFRESH_TOKEN && request.nextUrl.pathname.startsWith(PAGE_PATH.SIGN_IN)) {
-    return NextResponse.redirect(new URL(PAGE_PATH.DASHBOARD, request.url));
+  if (REFRESH_TOKEN) {
+    if (request.nextUrl.pathname.startsWith(PAGE_PATH.SIGN_IN)) {
+      return NextResponse.redirect(new URL(PAGE_PATH.DASHBOARD, request.url));
+    }
   }
 
   return NextResponse.next();
 };
 
 export const config = {
-  matcher: ["/((?!sign-in/.*$).*)"], // "sign-in/kakao"처럼 sign-in 뒤에 path 붙는 경로 제외
+  matcher: ["/:path*"],
 };

--- a/middleware.page.ts
+++ b/middleware.page.ts
@@ -9,9 +9,13 @@ export const middleware = (request: NextRequest) => {
     return NextResponse.redirect(new URL(PAGE_PATH.SIGN_IN, request.url));
   }
 
+  if (REFRESH_TOKEN && request.nextUrl.pathname.startsWith(PAGE_PATH.SIGN_IN)) {
+    return NextResponse.redirect(new URL(PAGE_PATH.DASHBOARD, request.url));
+  }
+
   return NextResponse.next();
 };
 
 export const config = {
-  matcher: ["/dashboard/:path*", "/calendar/:path*", "/group/:path*"],
+  matcher: ["/((?!sign-in/.*$).*)"], // "sign-in/kakao"처럼 sign-in 뒤에 path 붙는 경로 제외
 };

--- a/pages/sign-in/index.page.tsx
+++ b/pages/sign-in/index.page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import classNames from "classnames/bind";
 
 import MetaData from "@/components/MetaData";
+import { PAGE_PATH } from "@/constants/pagePath";
 
 import styles from "./SignIn.module.scss";
 
@@ -28,7 +29,9 @@ export default function SignIn() {
     <>
       <MetaData title="로그인 | 티키타" />
       <header className={cn("header")}>
-        <Image src="/icons/tickita-logo.svg" alt="로고 이미지" width={60} height={22} />
+        <Link href={PAGE_PATH.MAIN}>
+          <Image src="/icons/tickita-logo.svg" alt="로고 이미지" width={60} height={22} />
+        </Link>
       </header>
       <main className={cn("container")}>
         <div className={cn("tickita-logo")}>

--- a/pages/sign-in/profile-setup/index.page.tsx
+++ b/pages/sign-in/profile-setup/index.page.tsx
@@ -7,6 +7,7 @@ import classNames from "classnames/bind";
 import ProfileSetupForm from "./components/ProfileSetupForm/ProfileSetupForm";
 import { basicInstance } from "@/apis/axios";
 import MetaData from "@/components/MetaData";
+import { PAGE_PATH } from "@/constants/pagePath";
 
 import styles from "./ProfileSetup.module.scss";
 
@@ -20,12 +21,23 @@ interface ProfileSetupProps {
 export const getServerSideProps = async (context: GetServerSidePropsContext) => {
   const accountId = context.query.id;
 
-  const res = await basicInstance.get(`/account-info/${accountId}`);
-  const { email } = res.data;
+  try {
+    const res = await basicInstance.get(`/account-info/${accountId}`);
+    const { email } = res.data;
 
-  return {
-    props: { accountId, email },
-  };
+    return {
+      props: { accountId, email },
+    };
+  } catch (error) {
+    console.error(error);
+
+    return {
+      redirect: {
+        destination: PAGE_PATH.SIGN_IN,
+        permanent: false,
+      },
+    };
+  }
 };
 
 export default function ProfileSetup({ accountId, email }: ProfileSetupProps) {


### PR DESCRIPTION
## 🏁 작업 내용(필수)

- 미들웨어 로직을 수정하였습니다. refresh token을 가진 상태로, 로그인 관련 페이지에 접근 시, `/dashboard`로 이동됩니다.
- `/sign-in/profile-setup` 페이지에서 오류 발생 시, `/sign-in` 페이지로 이동합니다.