### PR TITLE
[fix] middleware를 통해 `/dashboard`로 이동 시 발생하는 오류 수정

### DIFF
--- a/middleware.page.ts
+++ b/middleware.page.ts
@@ -12,7 +12,10 @@ export const middleware = (request: NextRequest) => {
   }
 
   if (REFRESH_TOKEN) {
-    if (request.nextUrl.pathname.startsWith(PAGE_PATH.SIGN_IN)) {
+    if (
+      request.nextUrl.pathname.startsWith(PAGE_PATH.SIGN_IN) &&
+      request.nextUrl.pathname !== PAGE_PATH.SIGN_IN
+    ) {
       return NextResponse.redirect(new URL(PAGE_PATH.DASHBOARD, request.url));
     }
   }


### PR DESCRIPTION
## 🏁 작업 내용(필수)

- refresh token이 있는 상태로 `/sign-in` 접근 -> `/dashboard`로 강제 이동되었을 때, 유저 인증이 되지 않는 오류가 있어서,
- refresh token이 있어도, `/sign-in` 페이지에는 접근할 수 있도록 수정하였습니다... (구글 로그인 구현 후, 돌아와서 수정할게요...)