### PR TITLE
[fix] access token `max-age` 5분으로 설정

### DIFF
--- a/apis/axios.ts
+++ b/apis/axios.ts
@@ -112,13 +112,11 @@ instance.interceptors.response.use(
 
         // access token 재발급
         const refreshResponse = await instance.post("/token/refresh", { refresh: REFRESH_TOKEN });
-        const { accessToken, accessTokenExpireAt, refreshToken, refreshTokenExpireAt } =
-          refreshResponse.data;
+        const { accessToken, refreshToken, refreshTokenExpireAt } = refreshResponse.data;
 
         // cookie에 새로 발급받은 token 저장
         await nextInstance.post("/api/setCookies", {
           accessToken,
-          accessTokenExpireAt,
           refreshToken,
           refreshTokenExpireAt,
         });

--- a/pages/api/setCookies.page.ts
+++ b/pages/api/setCookies.page.ts
@@ -2,18 +2,17 @@ import { NextApiRequest, NextApiResponse } from "next";
 
 const handler = (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method === "POST") {
-    const { accessToken, accessTokenExpireAt, refreshToken, refreshTokenExpireAt } = req.body;
+    const { accessToken, refreshToken, refreshTokenExpireAt } = req.body;
 
     if (!accessToken || !refreshToken) {
       res.status(400).json({ message: "토큰이 존재하지 않습니다" });
       return;
     }
 
-    const ACCESS_TOKEN_EXPIRE_AT = new Date(accessTokenExpireAt).toUTCString();
     const REFRESH_TOKEN_EXPIRE_AT = new Date(refreshTokenExpireAt).toUTCString();
 
     res.setHeader("Set-Cookie", [
-      `ACCESS_TOKEN=${accessToken}; Path=/; HttpOnly; Secure; SameSite=Strict; Expires=${ACCESS_TOKEN_EXPIRE_AT}`,
+      `ACCESS_TOKEN=${accessToken}; Path=/; HttpOnly; Secure; SameSite=Strict; Max-age=3000`,
       `REFRESH_TOKEN=${refreshToken}; Path=/; HttpOnly; Secure; SameSite=Strict; Expires=${REFRESH_TOKEN_EXPIRE_AT}`,
     ]);
 

--- a/pages/sign-in/kakao/index.page.tsx
+++ b/pages/sign-in/kakao/index.page.tsx
@@ -44,20 +44,13 @@ export async function getServerSideProps(
       },
     });
 
-    const {
-      id,
-      isComplete,
-      accessToken,
-      accessTokenExpireAt,
-      refreshToken,
-      refreshTokenExpireAt,
-    }: ResponseType = res.data;
+    const { id, isComplete, accessToken, refreshToken, refreshTokenExpireAt }: ResponseType =
+      res.data;
 
     if (accessToken && refreshToken) {
-      const ACCESS_TOKEN_EXPIRE_AT = new Date(accessTokenExpireAt).toUTCString();
       const REFRESH_TOKEN_EXPIRE_AT = new Date(refreshTokenExpireAt).toUTCString();
 
-      const ACCESS_TOKEN = `ACCESS_TOKEN=${accessToken}; Path=/; HttpOnly; SameSite=Strict; Secure; Expires=${ACCESS_TOKEN_EXPIRE_AT}`;
+      const ACCESS_TOKEN = `ACCESS_TOKEN=${accessToken}; Path=/; HttpOnly; SameSite=Strict; Secure; Max-age=3000`;
       const REFRESH_TOKEN = `REFRESH_TOKEN=${refreshToken}; Path=/; HttpOnly; SameSite=Strict; Secure; Expires=${REFRESH_TOKEN_EXPIRE_AT}`;
 
       context.res.setHeader("Set-Cookie", [ACCESS_TOKEN, REFRESH_TOKEN]);


### PR DESCRIPTION
## 🏁 작업 내용(필수)

-배포 환경에서 `access token`의 `expires`가 지나도 제거되지 않는 오류가 있어, 프론트 측에서 `max-age`를 설정하는 방식으로 변경하였습니다.