### PR TITLE
[fix] access token `max-age` 수정

### DIFF
--- a/pages/api/setCookies.page.ts
+++ b/pages/api/setCookies.page.ts
@@ -12,7 +12,7 @@ const handler = (req: NextApiRequest, res: NextApiResponse) => {
     const REFRESH_TOKEN_EXPIRE_AT = new Date(refreshTokenExpireAt).toUTCString();
 
     res.setHeader("Set-Cookie", [
-      `ACCESS_TOKEN=${accessToken}; Path=/; HttpOnly; Secure; SameSite=Strict; Max-age=3000`,
+      `ACCESS_TOKEN=${accessToken}; Path=/; HttpOnly; Secure; SameSite=Strict; Max-age=300`,
       `REFRESH_TOKEN=${refreshToken}; Path=/; HttpOnly; Secure; SameSite=Strict; Expires=${REFRESH_TOKEN_EXPIRE_AT}`,
     ]);
 

--- a/pages/sign-in/kakao/index.page.tsx
+++ b/pages/sign-in/kakao/index.page.tsx
@@ -50,7 +50,7 @@ export async function getServerSideProps(
     if (accessToken && refreshToken) {
       const REFRESH_TOKEN_EXPIRE_AT = new Date(refreshTokenExpireAt).toUTCString();
 
-      const ACCESS_TOKEN = `ACCESS_TOKEN=${accessToken}; Path=/; HttpOnly; SameSite=Strict; Secure; Max-age=3000`;
+      const ACCESS_TOKEN = `ACCESS_TOKEN=${accessToken}; Path=/; HttpOnly; SameSite=Strict; Secure; Max-age=300`;
       const REFRESH_TOKEN = `REFRESH_TOKEN=${refreshToken}; Path=/; HttpOnly; SameSite=Strict; Secure; Expires=${REFRESH_TOKEN_EXPIRE_AT}`;
 
       context.res.setHeader("Set-Cookie", [ACCESS_TOKEN, REFRESH_TOKEN]);


### PR DESCRIPTION
## 🏁 작업 내용(필수)

- `access token`의 `max-age`가 50분으로 잘못 설정되어 있어서, 5분으로 수정하였습니다.