### PR TITLE
[feat] refresh token 가지고 있을 시, `/sign-in` 페이지 접근 불가

### DIFF
--- a/middleware.page.ts
+++ b/middleware.page.ts
@@ -11,6 +11,12 @@ export const middleware = (request: NextRequest) => {
     }
   }
 
+  if (REFRESH_TOKEN) {
+    if (request.nextUrl.pathname.startsWith(PAGE_PATH.SIGN_IN)) {
+      return NextResponse.redirect(new URL(PAGE_PATH.DASHBOARD, request.url));
+    }
+  }
+
   return NextResponse.next();
 };
 


### PR DESCRIPTION
## 🏁 작업 내용(필수)

- `refresh token`을 가진 상태로, `/sign-in`에 접근할 경우, `/dashboard`로 이동합니다.