### PR TITLE
[feat]주간캘린더 스케줄바 구현

### DIFF
--- a/pages/calendar/components/Calendar/DailyCalendar/index.tsx
+++ b/pages/calendar/components/Calendar/DailyCalendar/index.tsx
@@ -78,9 +78,9 @@ export default function DailyCalendar({ scheduleData }: DailyCalendarProps) {
           </div>
         ))}
         {scheduleData.map(
-          (queryResult: any) =>
+          (queryResult: any, index: number) =>
             Array.isArray(queryResult.data) &&
-            queryResult.data.map((schedule: any, index: number) => {
+            queryResult.data.map((schedule: any) => {
               const start = dayjs(schedule.startDateTime);
               const end = dayjs(schedule.endDateTime);
               return end.diff(start, "days") === 0 ? (

--- a/pages/calendar/components/Calendar/DailyCalendar/index.tsx
+++ b/pages/calendar/components/Calendar/DailyCalendar/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 
 import classNames from "classnames/bind";
 import dayjs from "dayjs";
@@ -39,10 +39,6 @@ export default function DailyCalendar({ scheduleData }: DailyCalendarProps) {
   };
 
   const { draggedIndex } = useDragSelect(dragContainerRef, handleDragEnd);
-
-  useEffect(() => {
-    console.log(scheduleData);
-  }, []);
 
   return (
     <div className={cn("container")}>

--- a/pages/calendar/components/Calendar/WeeklyCalendar/WeeklyCalendar.module.scss
+++ b/pages/calendar/components/Calendar/WeeklyCalendar/WeeklyCalendar.module.scss
@@ -49,14 +49,14 @@
 
   .weekly-all-day-container {
     width: 100%;
-    height: 5rem;
+    height: 7.5rem;
     border-bottom: 1px solid $gray400;
 
   }
 
   .time-scroll-container {
     width: 100%;
-    height: calc(100vh - 21.875rem);
+    height: calc(100vh - 28.125rem);
     display: flex;
     overflow-y: auto;
 

--- a/pages/calendar/components/Calendar/WeeklyCalendar/WeeklyCalendar.module.scss
+++ b/pages/calendar/components/Calendar/WeeklyCalendar/WeeklyCalendar.module.scss
@@ -91,6 +91,7 @@
         display: flex;
         flex-direction: column;
         border-left: 1px solid $gray300;
+        position: relative;
 
         &:first-child {
           border-left: none;

--- a/pages/calendar/components/Calendar/WeeklyCalendar/WeeklyCalendar.module.scss
+++ b/pages/calendar/components/Calendar/WeeklyCalendar/WeeklyCalendar.module.scss
@@ -50,8 +50,9 @@
   .weekly-all-day-container {
     width: 100%;
     height: 7.5rem;
+    padding-left: 5rem;
     border-bottom: 1px solid $gray400;
-
+    position: relative;
   }
 
   .time-scroll-container {

--- a/pages/calendar/components/Calendar/WeeklyCalendar/WeeklyCalendar.module.scss
+++ b/pages/calendar/components/Calendar/WeeklyCalendar/WeeklyCalendar.module.scss
@@ -47,9 +47,16 @@
     }
   }
 
+  .weekly-all-day-container {
+    width: 100%;
+    height: 5rem;
+    border-bottom: 1px solid $gray400;
+
+  }
+
   .time-scroll-container {
     width: 100%;
-    height: calc(100vh - 15.625rem);
+    height: calc(100vh - 21.875rem);
     display: flex;
     overflow-y: auto;
 

--- a/pages/calendar/components/Calendar/WeeklyCalendar/index.tsx
+++ b/pages/calendar/components/Calendar/WeeklyCalendar/index.tsx
@@ -13,6 +13,7 @@ import { calculateWeekDates } from "@/utils/calculateCalendarDates";
 import { CrewSchedulesType } from "@/types/type";
 
 import styles from "./WeeklyCalendar.module.scss";
+import WeeklyOneDayScheduleBar from "../../ScheduleBar/WeeklyScheduleBar";
 
 const cn = classNames.bind(styles);
 
@@ -92,6 +93,25 @@ export default function WeeklyCalendar({ scheduleData }: WeeklyCalendarProps) {
                   onPointerUp={handleDragEnd}
                 />
               ))}
+              {scheduleData.map(
+                (queryResult: any) =>
+                  Array.isArray(queryResult.data) &&
+                  queryResult.data.map((schedule: any, index: number) => {
+                    const start = dayjs(schedule.startDateTime);
+                    const end = dayjs(schedule.endDateTime);
+                    return start.day() === date.day() && end.diff(start, "days") === 0 ? (
+                      <WeeklyOneDayScheduleBar
+                        index={index}
+                        key={schedule.scheduleId}
+                        scheduleId={schedule.scheduleId}
+                        startDate={schedule.startDateTime}
+                        endDate={schedule.endDateTime}
+                        title={schedule.title}
+                        crewColor={schedule.crewInfo.labelColor}
+                      />
+                    ) : null;
+                  }),
+              )}
             </div>
           ))}
         </div>

--- a/pages/calendar/components/Calendar/WeeklyCalendar/index.tsx
+++ b/pages/calendar/components/Calendar/WeeklyCalendar/index.tsx
@@ -69,6 +69,7 @@ export default function WeeklyCalendar({ scheduleData }: WeeklyCalendarProps) {
           </div>
         ))}
       </div>
+      <div className={cn("weekly-all-day-container")}></div>
       <div className={cn("time-scroll-container")}>
         <div className={cn("label-container")}>
           {HOURS.map((hour) => (
@@ -96,12 +97,11 @@ export default function WeeklyCalendar({ scheduleData }: WeeklyCalendarProps) {
               {scheduleData.map(
                 (queryResult: any) =>
                   Array.isArray(queryResult.data) &&
-                  queryResult.data.map((schedule: any, index: number) => {
+                  queryResult.data.map((schedule: any) => {
                     const start = dayjs(schedule.startDateTime);
                     const end = dayjs(schedule.endDateTime);
                     return start.day() === date.day() && end.diff(start, "days") === 0 ? (
                       <WeeklyOneDayScheduleBar
-                        index={index}
                         key={schedule.scheduleId}
                         scheduleId={schedule.scheduleId}
                         startDate={schedule.startDateTime}

--- a/pages/calendar/components/ScheduleBar/DailyScheduleBar/DailyScheduleBar.module.scss
+++ b/pages/calendar/components/ScheduleBar/DailyScheduleBar/DailyScheduleBar.module.scss
@@ -1,8 +1,8 @@
 .container {
-  width: 18.75rem;
+  width: 10.625rem;
   border-radius: 0.75rem;
   padding-top: 0.65rem;
-
+  border-top: 1px solid $gray300;
   outline: none;
   cursor: pointer;
   position: absolute;
@@ -16,6 +16,7 @@
   .title {
     @include caption1-medium($white);
     font-size: 1rem;
+    overflow-wrap: normal;
   }
 
   &:hover {

--- a/pages/calendar/components/ScheduleBar/DailyScheduleBar/DailyScheduleBar.module.scss
+++ b/pages/calendar/components/ScheduleBar/DailyScheduleBar/DailyScheduleBar.module.scss
@@ -8,8 +8,7 @@
   position: absolute;
   opacity: 0.85;
 
-  .start,
-  .end {
+  .time {
     @include caption2-medium($white);
     font-size: 0.9rem;
   }

--- a/pages/calendar/components/ScheduleBar/DailyScheduleBar/DailyScheduleBar.module.scss
+++ b/pages/calendar/components/ScheduleBar/DailyScheduleBar/DailyScheduleBar.module.scss
@@ -2,7 +2,7 @@
   width: 10.625rem;
   border-radius: 0.75rem;
   padding-top: 0.65rem;
-  border-top: 1px solid $gray300;
+  border-top: 2px solid $gray300;
   outline: none;
   cursor: pointer;
   position: absolute;
@@ -20,7 +20,7 @@
   }
 
   &:hover {
-    filter: brightness(1.1);
+    filter: brightness(1.2);
     transition: 0.75s;
   }
 }

--- a/pages/calendar/components/ScheduleBar/DailyScheduleBar/index.tsx
+++ b/pages/calendar/components/ScheduleBar/DailyScheduleBar/index.tsx
@@ -28,16 +28,15 @@ export default function DailyScheduleBar({
   const end = dayjs(endDate);
 
   const startHour = start.get("hour");
-  const endHour = end.get("hour");
   const timeDiff = end.diff(start, "hours");
-  const zIndex = 25 - timeDiff;
+  const zIndex = 2 + startHour;
   return (
     <div
       className={cn("container")}
       style={{
         backgroundColor: crewColor,
         zIndex: zIndex,
-        left: `${70 + index * 130}px`,
+        left: `${70 + index * 180}px`,
         top: `${startHour * 56 + 1}px`,
         height: `${56 * timeDiff}px`,
       }}
@@ -62,13 +61,11 @@ export function DailyAllDayScheduleBar({
   const end = dayjs(endDate);
 
   return (
-    <>
-      <div className={cn("all-container")} style={{ backgroundColor: crewColor, zIndex: "2" }}>
-        <p className={cn("end")}>
-          ~ {end.format("MM")}.{end.format("DD")} 까지
-        </p>
-        <p className={cn("title")}>{title}</p>
-      </div>
-    </>
+    <div className={cn("all-container")} style={{ backgroundColor: crewColor, zIndex: "2" }}>
+      <p className={cn("end")}>
+        ~ {end.format("MM")}.{end.format("DD")} 까지
+      </p>
+      <p className={cn("title")}>{title}</p>
+    </div>
   );
 }

--- a/pages/calendar/components/ScheduleBar/DailyScheduleBar/index.tsx
+++ b/pages/calendar/components/ScheduleBar/DailyScheduleBar/index.tsx
@@ -43,7 +43,7 @@ export default function DailyScheduleBar({
       }}
     >
       <p className={cn("start")}>
-        {String(startHour).padStart(2, "0")}시 ~ {String(endHour).padStart(2, "0")}시
+        {start.format("hh")}시 ~ {end.format("hh")}시
       </p>
       <p className={cn("title")}>{title}</p>
     </div>
@@ -65,7 +65,7 @@ export function DailyAllDayScheduleBar({
     <>
       <div className={cn("all-container")} style={{ backgroundColor: crewColor, zIndex: "2" }}>
         <p className={cn("end")}>
-          ~ {end.get("M")}.{end.get("date")} 까지
+          ~ {end.format("MM")}.{end.format("DD")} 까지
         </p>
         <p className={cn("title")}>{title}</p>
       </div>

--- a/pages/calendar/components/ScheduleBar/DailyScheduleBar/index.tsx
+++ b/pages/calendar/components/ScheduleBar/DailyScheduleBar/index.tsx
@@ -42,8 +42,8 @@ export default function DailyScheduleBar({
         height: `${56 * timeDiff}px`,
       }}
     >
-      <p className={cn("start")}>
-        {start.format("hh")}시 ~ {end.format("hh")}시
+      <p className={cn("time")}>
+        {start.format("HH : mm")} ~ {end.format("HH : mm")}
       </p>
       <p className={cn("title")}>{title}</p>
     </div>

--- a/pages/calendar/components/ScheduleBar/WeeklyScheduleBar/WeeklyScheduleBar.module.scss
+++ b/pages/calendar/components/ScheduleBar/WeeklyScheduleBar/WeeklyScheduleBar.module.scss
@@ -1,19 +1,20 @@
 .container {
-  width: calc(100% - 1.375rem);
+  width: calc(100% - 1.875rem);
   border-radius: .75rem;
-
+  padding-top: 1rem;
   outline: none;
   cursor: pointer;
   position: absolute;
-  opacity: 0.75;
+  opacity: 0.85;
 
-  .start,
-  .end {
+  .time {
     @include caption2-medium($white);
+    font-size: 0.9rem;
   }
 
   .title {
     @include caption1-medium($white);
+    font-size: 1rem;
   }
 
   &:hover {

--- a/pages/calendar/components/ScheduleBar/WeeklyScheduleBar/WeeklyScheduleBar.module.scss
+++ b/pages/calendar/components/ScheduleBar/WeeklyScheduleBar/WeeklyScheduleBar.module.scss
@@ -6,7 +6,7 @@
   cursor: pointer;
   position: absolute;
   opacity: 0.85;
-  border-top: 1px solid $gray300;
+  border-top: 2px solid $gray300;
 
   .time {
     @include caption2-medium($white);
@@ -16,9 +16,41 @@
   .title {
     @include caption1-medium($white);
     font-size: 1rem;
+    overflow-wrap: normal;
   }
 
   &:hover {
-    filter: brightness(1.1);
+    filter: brightness(1.2);
+    transition: 0.75s;
+  }
+}
+
+
+.all-container {
+  height: 1.5625rem;
+  padding: .125rem .3125rem;
+  border-left: 2px solid $gray700;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 5px;
+  outline: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  position: absolute;
+
+  &:hover {
+    filter: brightness(1.2);
+    transition: 0.75s;
+  }
+
+  .time {
+    @include caption2-medium($white);
+    font-size: 0.9rem;
+  }
+
+  .title {
+    @include caption1-medium($white);
+    font-size: 1rem;
   }
 }

--- a/pages/calendar/components/ScheduleBar/WeeklyScheduleBar/WeeklyScheduleBar.module.scss
+++ b/pages/calendar/components/ScheduleBar/WeeklyScheduleBar/WeeklyScheduleBar.module.scss
@@ -1,0 +1,22 @@
+.container {
+  width: calc(100% - 1.375rem);
+  border-radius: .75rem;
+
+  outline: none;
+  cursor: pointer;
+  position: absolute;
+  opacity: 0.75;
+
+  .start,
+  .end {
+    @include caption2-medium($white);
+  }
+
+  .title {
+    @include caption1-medium($white);
+  }
+
+  &:hover {
+    filter: brightness(1.1);
+  }
+}

--- a/pages/calendar/components/ScheduleBar/WeeklyScheduleBar/WeeklyScheduleBar.module.scss
+++ b/pages/calendar/components/ScheduleBar/WeeklyScheduleBar/WeeklyScheduleBar.module.scss
@@ -6,6 +6,7 @@
   cursor: pointer;
   position: absolute;
   opacity: 0.85;
+  border-top: 1px solid $gray300;
 
   .time {
     @include caption2-medium($white);

--- a/pages/calendar/components/ScheduleBar/WeeklyScheduleBar/index.tsx
+++ b/pages/calendar/components/ScheduleBar/WeeklyScheduleBar/index.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames/bind";
-import dayjs from "dayjs";
+import dayjs, { Dayjs } from "dayjs";
 
 import { GroupColorType } from "@/types/type";
 
@@ -46,24 +46,47 @@ export default function WeeklyOneDayScheduleBar({
   );
 }
 
+interface WeeklyScheduleBarType extends ScheduleBarType {
+  crewIndex: number;
+  elementWidth: number;
+  weekStartDate: Dayjs;
+}
+
 export function WeeklyScheduleBar({
   scheduleId,
   title,
   startDate,
   endDate,
   crewColor,
-}: ScheduleBarType) {
+  crewIndex,
+  elementWidth,
+  weekStartDate,
+}: WeeklyScheduleBarType) {
   const start = dayjs(startDate);
   const end = dayjs(endDate);
-
   const zIndex = 2 + start.day();
+  const weekEnd = weekStartDate.add(6, "day");
+
+  const adjustedStart = start.isBefore(weekStartDate) ? weekStartDate : start;
+  const adjustedEnd = end.isAfter(weekEnd) ? weekEnd : end;
+  //칸수
+  const daysOccupied = adjustedEnd.diff(adjustedStart, "day");
+  const width = `${daysOccupied * elementWidth}px`;
 
   return (
-    <div className={cn("all-continaer")} style={{ backgroundColor: crewColor, zIndex: zIndex }}>
-      <div className={cn("time")}>
-        <p className={cn("start")}>{start.format("MM.DD HH:mm")}</p>
-        <p className={cn("end")}>~ {end.format("MM.DD HH:mm")}</p>
-      </div>
+    <div
+      className={cn("all-container")}
+      style={{
+        backgroundColor: crewColor,
+        zIndex: zIndex,
+        top: `${crewIndex * 27 + 1}px`,
+        left: `${adjustedStart.day() * elementWidth + 100}px`,
+        width: width,
+      }}
+    >
+      <p className={cn("time")}>
+        {start.format("MM.DD")} ~ {end.format("MM.DD")}
+      </p>
       <p className={cn("title")}>{title}</p>
     </div>
   );

--- a/pages/calendar/components/ScheduleBar/WeeklyScheduleBar/index.tsx
+++ b/pages/calendar/components/ScheduleBar/WeeklyScheduleBar/index.tsx
@@ -1,4 +1,4 @@
-import classNames from "classnames";
+import classNames from "classnames/bind";
 import dayjs from "dayjs";
 
 import { GroupColorType } from "@/types/type";
@@ -28,22 +28,20 @@ export default function WeeklyOneDayScheduleBar({
   const end = dayjs(endDate);
   const startHour = start.get("hour");
   const timeDiff = end.diff(start, "hours");
-
+  const zIndex = 25 - timeDiff;
   return (
     <div
       className={cn("container")}
       style={{
         backgroundColor: crewColor,
-        left: "10px",
+        left: "15px",
+        zIndex: zIndex,
         top: `${startHour * 80 + 1}px`,
         height: `${80 * timeDiff}px`,
       }}
     >
-      <p className={cn("start")}>
-        {start.format("hh")}.{start.format("mm")}
-      </p>
-      <p className={cn("end")}>
-        ~ {end.format("hh")}.{end.format("mm")}
+      <p className={cn("time")}>
+        {start.format("hh")}.{start.format("mm")} ~ {end.format("hh")}.{end.format("mm")}
       </p>
       <p className={cn("title")}>{title}</p>
     </div>

--- a/pages/calendar/components/ScheduleBar/WeeklyScheduleBar/index.tsx
+++ b/pages/calendar/components/ScheduleBar/WeeklyScheduleBar/index.tsx
@@ -1,0 +1,53 @@
+import classNames from "classnames";
+import dayjs from "dayjs";
+
+import { GroupColorType } from "@/types/type";
+
+import styles from "./WeeklyScheduleBar.module.scss";
+
+interface ScheduleBarType {
+  index: number;
+  scheduleId: number;
+  title: string;
+  startDate: string;
+  endDate: string;
+  crewColor: GroupColorType;
+}
+
+const cn = classNames.bind(styles);
+
+export default function WeeklyOneDayScheduleBar({
+  index,
+  scheduleId,
+  title,
+  startDate,
+  endDate,
+  crewColor,
+}: ScheduleBarType) {
+  const start = dayjs(startDate);
+  const end = dayjs(endDate);
+  const startHour = start.get("hour");
+  const timeDiff = end.diff(start, "hours");
+
+  return (
+    <div
+      className={cn("container")}
+      style={{
+        backgroundColor: crewColor,
+        left: "10px",
+        top: `${startHour * 80 + 1}px`,
+        height: `${80 * timeDiff}px`,
+      }}
+    >
+      <p className={cn("start")}>
+        {start.format("hh")}.{start.format("mm")}
+      </p>
+      <p className={cn("end")}>
+        ~ {end.format("hh")}.{end.format("mm")}
+      </p>
+      <p className={cn("title")}>{title}</p>
+    </div>
+  );
+}
+
+export function WeeklyScheduleBar({}) {}

--- a/pages/calendar/components/ScheduleBar/WeeklyScheduleBar/index.tsx
+++ b/pages/calendar/components/ScheduleBar/WeeklyScheduleBar/index.tsx
@@ -39,7 +39,7 @@ export default function WeeklyOneDayScheduleBar({
       }}
     >
       <p className={cn("time")}>
-        {start.format("hh")}.{start.format("mm")} ~ {end.format("hh")}.{end.format("mm")}
+        {start.format("HH : mm")} ~ {end.format("HH : mm")}
       </p>
       <p className={cn("title")}>{title}</p>
     </div>

--- a/pages/calendar/components/ScheduleBar/WeeklyScheduleBar/index.tsx
+++ b/pages/calendar/components/ScheduleBar/WeeklyScheduleBar/index.tsx
@@ -35,7 +35,7 @@ export default function WeeklyOneDayScheduleBar({
         left: "15px",
         zIndex: zIndex,
         top: `${startHour * 80 + 1}px`,
-        height: `${80 * timeDiff}px`,
+        height: `${80 * timeDiff - 5}px`,
       }}
     >
       <p className={cn("time")}>
@@ -52,4 +52,19 @@ export function WeeklyScheduleBar({
   startDate,
   endDate,
   crewColor,
-}: ScheduleBarType) {}
+}: ScheduleBarType) {
+  const start = dayjs(startDate);
+  const end = dayjs(endDate);
+
+  const zIndex = 2 + start.day();
+
+  return (
+    <div className={cn("all-continaer")} style={{ backgroundColor: crewColor, zIndex: zIndex }}>
+      <div className={cn("time")}>
+        <p className={cn("start")}>{start.format("MM.DD HH:mm")}</p>
+        <p className={cn("end")}>~ {end.format("MM.DD HH:mm")}</p>
+      </div>
+      <p className={cn("title")}>{title}</p>
+    </div>
+  );
+}

--- a/pages/calendar/components/ScheduleBar/WeeklyScheduleBar/index.tsx
+++ b/pages/calendar/components/ScheduleBar/WeeklyScheduleBar/index.tsx
@@ -6,7 +6,6 @@ import { GroupColorType } from "@/types/type";
 import styles from "./WeeklyScheduleBar.module.scss";
 
 interface ScheduleBarType {
-  index: number;
   scheduleId: number;
   title: string;
   startDate: string;
@@ -17,7 +16,6 @@ interface ScheduleBarType {
 const cn = classNames.bind(styles);
 
 export default function WeeklyOneDayScheduleBar({
-  index,
   scheduleId,
   title,
   startDate,
@@ -28,7 +26,7 @@ export default function WeeklyOneDayScheduleBar({
   const end = dayjs(endDate);
   const startHour = start.get("hour");
   const timeDiff = end.diff(start, "hours");
-  const zIndex = 25 - timeDiff;
+  const zIndex = startHour + 2;
   return (
     <div
       className={cn("container")}
@@ -48,4 +46,10 @@ export default function WeeklyOneDayScheduleBar({
   );
 }
 
-export function WeeklyScheduleBar({}) {}
+export function WeeklyScheduleBar({
+  scheduleId,
+  title,
+  startDate,
+  endDate,
+  crewColor,
+}: ScheduleBarType) {}


### PR DESCRIPTION
# 🎯 이슈 번호

- #114 

## 🏁 작업 내용(필수)

- 주간캘린더 스케줄바를 구현했습니다
- 주간 캘린더에서 여러 일에 걸치는 일정과, 한 날짜에 있는일정을 분리해서 스케줄바 컴포넌트를 랜더링합니다

## 💬 리뷰 요구 사항

-
-

## 📢 참고 사항

-
-
