### PR TITLE
[feat]일정 생성하기 버튼 연결 구현

### DIFF
--- a/pages/calendar/components/CalendarSideBar/index.tsx
+++ b/pages/calendar/components/CalendarSideBar/index.tsx
@@ -3,9 +3,14 @@ import { Dispatch, SetStateAction, useState } from "react";
 import Image from "next/image";
 
 import classNames from "classnames/bind";
+import dayjs from "dayjs";
+import { useShallow } from "zustand/react/shallow";
 
 import DatePicker from "@/components/DatePicker/DatePicker";
+import { MODAL_TYPE } from "@/constants/modalType";
 import { useOutsideClick } from "@/hooks/useOutsideClick";
+import { useDateStore } from "@/store/useDateStore";
+import { useModalStore } from "@/store/useModalStore";
 
 import styles from "./CalendarSideBar.module.scss";
 import CalendarGroupList from "../CalendarGroupList";
@@ -17,11 +22,25 @@ interface CalendarSideBarProps {
 }
 
 export default function CalendarSideBar({ setSelectedCrewIdList }: CalendarSideBarProps) {
+  const { focusDate, setScheduleStart, setScheduleEnd } = useDateStore(
+    useShallow((state) => ({
+      focusDate: state.focusDate,
+      setScheduleStart: state.setScheduleStart,
+      setScheduleEnd: state.setScheduleEnd,
+    })),
+  );
+  const { openModal } = useModalStore();
   const [isCreateListVisible, setIsCreateListVisible] = useState(false);
   const scheduleContainerRef = useOutsideClick<HTMLDivElement>(() => setIsCreateListVisible(false));
 
   const handleListVisibleToggle = () => {
     setIsCreateListVisible((prev) => !prev);
+  };
+
+  const handleCreateModalOpen = () => {
+    setScheduleStart(dayjs(focusDate).startOf("day"));
+    setScheduleEnd(dayjs(focusDate).add(1, "day").startOf("day"));
+    openModal(MODAL_TYPE.SCHEDULE_CREATE);
   };
 
   return (
@@ -37,7 +56,7 @@ export default function CalendarSideBar({ setSelectedCrewIdList }: CalendarSideB
         </div>
         {isCreateListVisible && (
           <ul className={cn("create-list-container")}>
-            <li>일정 만들기</li>
+            <li onClick={handleCreateModalOpen}>일정 만들기</li>
             <li>일정 조율하기</li>
           </ul>
         )}


### PR DESCRIPTION
# 🎯 이슈 번호

- #

## 🏁 작업 내용(필수)

- 일정 생성 버튼 클릭시 생성모달 열리도록 연결
- 현재 포커스되어있는 날짜의 하루일정 (그날 00시~ 다음날 00시) 로 일정이 생성되는 모달이 뜹니다!

## 💬 리뷰 요구 사항

-
-

## 📢 참고 사항

-
-
